### PR TITLE
Modify anchor href of "back to top" button

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
             <div class="gotop">
                 <div class= "emptyBox"></div>
                 <div class= "gotop">
-                  <p><a href="index.html#top" class="linkImage"><img src="gotop.png" width="15%"></a></p>
+                  <p><a href="#top" class="linkImage"><img src="gotop.png" width="15%"></a></p>
                   <p class="caption">Back to Top</p>
                 </div>
             <div class= "emptyBox"></div>


### PR DESCRIPTION
Currently the link occurs a page reloading when the user is in the default path (`/`). It may be an unexpected behaviour.
So I change the link's href from `index#top` to just `#top
